### PR TITLE
Hidden user name

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ See [`_team.json`](_team.json) for its example
 
 #### Pull Request
 
-You need to add `HUBOT_URL/hubot/github-pull-request?room=ROOM[&only-mentioned=1][&randm-mention=1]` to your repository's webhooks.
+You need to add `HUBOT_URL/hubot/github-pull-request?room=ROOM[&only-mentioned=1][&randm-mention=1][&hidden-user-name=1]` to your repository's webhooks.
 
 | Parameter | Description |
 | -------- | ----------- |
@@ -72,10 +72,11 @@ You need to add `HUBOT_URL/hubot/github-pull-request?room=ROOM[&only-mentioned=1
 - When `&only-mentioned=1` is added, it sends notifications only when there are `@` mentions.
 - When `&random-mention=1` is added, it picks-up a user from team.json and send notification.
   - You can specify more than `2` in the value to pick-up more than two users.
+- When `&hidden-user-name=1` is added, it hide user name from notification sentence.
 
 #### Issue
 
-You need to add `HUBOT_URL/hubot/github-issue?room=ROOM[&only-mentioned=1]` to your repository's webhooks.
+You need to add `HUBOT_URL/hubot/github-issue?room=ROOM[&only-mentioned=1][&hidden-user-name=1]` to your repository's webhooks.
 
 | Parameter | Description |
 | -------- | ----------- |
@@ -83,3 +84,4 @@ You need to add `HUBOT_URL/hubot/github-issue?room=ROOM[&only-mentioned=1]` to y
 | `ROOM` | To which room you want to send notification |
 
 - When `&only-mentioned=1` is added, it sends notifications only when there are `@` mentions.
+- When `&hidden-user-name=1` is added, it hide user name from notification sentence.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ See [`_team.json`](_team.json) for its example
 
 #### Pull Request
 
-You need to add `HUBOT_URL/hubot/github-pull-request?room=ROOM[&only-mentioned=1][&randm-mention=1][&ignore-author=1]` to your repository's webhooks.
+You need to add `HUBOT_URL/hubot/github-pull-request?room=ROOM[&only-mentioned=1][&randm-mention=1][&ignore-sender=1]` to your repository's webhooks.
 
 | Parameter | Description |
 | -------- | ----------- |
@@ -72,11 +72,11 @@ You need to add `HUBOT_URL/hubot/github-pull-request?room=ROOM[&only-mentioned=1
 - When `&only-mentioned=1` is added, it sends notifications only when there are `@` mentions.
 - When `&random-mention=1` is added, it picks-up a user from team.json and send notification.
   - You can specify more than `2` in the value to pick-up more than two users.
-- When `&ignore-author=1` is added, it hide user name from notification sentence.
+- When `&ignore-sender=1` is added, it hide user name from notification sentence.
 
 #### Issue
 
-You need to add `HUBOT_URL/hubot/github-issue?room=ROOM[&only-mentioned=1][&ignore-author=1]` to your repository's webhooks.
+You need to add `HUBOT_URL/hubot/github-issue?room=ROOM[&only-mentioned=1][&ignore-sender=1]` to your repository's webhooks.
 
 | Parameter | Description |
 | -------- | ----------- |
@@ -84,4 +84,4 @@ You need to add `HUBOT_URL/hubot/github-issue?room=ROOM[&only-mentioned=1][&igno
 | `ROOM` | To which room you want to send notification |
 
 - When `&only-mentioned=1` is added, it sends notifications only when there are `@` mentions.
-- When `&ignore-author=1` is added, it hide user name from notification sentence.
+- When `&ignore-sender=1` is added, it hide user name from notification sentence.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ See [`_team.json`](_team.json) for its example
 
 #### Pull Request
 
-You need to add `HUBOT_URL/hubot/github-pull-request?room=ROOM[&only-mentioned=1][&randm-mention=1][&hidden-user-name=1]` to your repository's webhooks.
+You need to add `HUBOT_URL/hubot/github-pull-request?room=ROOM[&only-mentioned=1][&randm-mention=1][&ignore-author=1]` to your repository's webhooks.
 
 | Parameter | Description |
 | -------- | ----------- |
@@ -72,11 +72,11 @@ You need to add `HUBOT_URL/hubot/github-pull-request?room=ROOM[&only-mentioned=1
 - When `&only-mentioned=1` is added, it sends notifications only when there are `@` mentions.
 - When `&random-mention=1` is added, it picks-up a user from team.json and send notification.
   - You can specify more than `2` in the value to pick-up more than two users.
-- When `&hidden-user-name=1` is added, it hide user name from notification sentence.
+- When `&ignore-author=1` is added, it hide user name from notification sentence.
 
 #### Issue
 
-You need to add `HUBOT_URL/hubot/github-issue?room=ROOM[&only-mentioned=1][&hidden-user-name=1]` to your repository's webhooks.
+You need to add `HUBOT_URL/hubot/github-issue?room=ROOM[&only-mentioned=1][&ignore-author=1]` to your repository's webhooks.
 
 | Parameter | Description |
 | -------- | ----------- |
@@ -84,4 +84,4 @@ You need to add `HUBOT_URL/hubot/github-issue?room=ROOM[&only-mentioned=1][&hidd
 | `ROOM` | To which room you want to send notification |
 
 - When `&only-mentioned=1` is added, it sends notifications only when there are `@` mentions.
-- When `&hidden-user-name=1` is added, it hide user name from notification sentence.
+- When `&ignore-author=1` is added, it hide user name from notification sentence.

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -14,8 +14,9 @@ exports.buildMessage = (parts, opts) ->
   random_mentions = if parts.random then random(mentions, opts.random_mention, opts.mention_team) else []
   return null if opts.only_mentioned and mentions.length is 0 and random_mentions.length is 0
   msg = ""
-  msg += "[#{parts.repository}] #{parts.action}: ##{parts.number} #{parts.title} by #{parts.user}\n"
-  msg += "#{parts.url}\n"
+  msg += "[#{parts.repository}] #{parts.action}: ##{parts.number} #{parts.title}"
+  msg += " by #{parts.user}" unless opts.hidden_user_name
+  msg += "\n#{parts.url}\n"
   msg += "#{parts.body}\n" if parts.body
   msg += "Mentions: #{mentions.join(", ")}\n" if mentions.length
   msg += "Congratulations! You are assigned: #{random_mentions.join(", ")}\n" if random_mentions.length

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -15,7 +15,7 @@ exports.buildMessage = (parts, opts) ->
   return null if opts.only_mentioned and mentions.length is 0 and random_mentions.length is 0
   msg = ""
   msg += "[#{parts.repository}] #{parts.action}: ##{parts.number} #{parts.title}"
-  msg += " by #{parts.user}" unless opts.hidden_user_name
+  msg += " by #{parts.user}" unless opts.ignore_author
   msg += "\n#{parts.url}\n"
   msg += "#{parts.body}\n" if parts.body
   msg += "Mentions: #{mentions.join(", ")}\n" if mentions.length

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -15,7 +15,7 @@ exports.buildMessage = (parts, opts) ->
   return null if opts.only_mentioned and mentions.length is 0 and random_mentions.length is 0
   msg = ""
   msg += "[#{parts.repository}] #{parts.action}: ##{parts.number} #{parts.title}"
-  msg += " by #{parts.user}" unless opts.ignore_author
+  msg += " by #{parts.user}" unless opts.ignore_sender
   msg += "\n#{parts.url}\n"
   msg += "#{parts.body}\n" if parts.body
   msg += "Mentions: #{mentions.join(", ")}\n" if mentions.length

--- a/src/github-issue.coffee
+++ b/src/github-issue.coffee
@@ -7,9 +7,9 @@
 #   You need to add `HUBOT_URL/hubot/github-issue?room=ROOM[&only-mentioned=1]` to your repository's webhooks.
 #     HUBOT_URL: Your Hubot server's url
 #     ROOM` To which room you want to send notification
-#
+# 
 #     When `&only-commented=1` is added, it sends notifications only when there are `@` mentions.
-#
+# 
 # Author:
 #   yujiosaka
 

--- a/src/github-issue.coffee
+++ b/src/github-issue.coffee
@@ -7,9 +7,9 @@
 #   You need to add `HUBOT_URL/hubot/github-issue?room=ROOM[&only-mentioned=1]` to your repository's webhooks.
 #     HUBOT_URL: Your Hubot server's url
 #     ROOM` To which room you want to send notification
-# 
+#
 #     When `&only-commented=1` is added, it sends notifications only when there are `@` mentions.
-# 
+#
 # Author:
 #   yujiosaka
 
@@ -25,6 +25,7 @@ module.exports = (robot) ->
     query = querystring.parse url.parse(req.url).query
     opts =
       only_mentioned: query["only-mentioned"]
+      hidden_user_name: query["hidden-user-name"]
     parts = parseBody req.body
     message = lib.buildMessage parts, opts
     robot.send {room: query.room}, message if message

--- a/src/github-issue.coffee
+++ b/src/github-issue.coffee
@@ -25,7 +25,7 @@ module.exports = (robot) ->
     query = querystring.parse url.parse(req.url).query
     opts =
       only_mentioned: query["only-mentioned"]
-      hidden_user_name: query["hidden-user-name"]
+      ignore_author: query["ignore-author"]
     parts = parseBody req.body
     message = lib.buildMessage parts, opts
     robot.send {room: query.room}, message if message

--- a/src/github-issue.coffee
+++ b/src/github-issue.coffee
@@ -25,7 +25,7 @@ module.exports = (robot) ->
     query = querystring.parse url.parse(req.url).query
     opts =
       only_mentioned: query["only-mentioned"]
-      ignore_author: query["ignore-author"]
+      ignore_sender: query["ignore-sender"]
     parts = parseBody req.body
     message = lib.buildMessage parts, opts
     robot.send {room: query.room}, message if message

--- a/src/github-pull-request.coffee
+++ b/src/github-pull-request.coffee
@@ -7,9 +7,9 @@
 #   You need to add `HUBOT_URL/hubot/github-pull-request?room=ROOM[&only-mentioned=1]` to your repository's webhooks.
 #     HUBOT_URL: Your Hubot server's url
 #     ROOM` To which room you want to send notification
-#
+# 
 #     When `&only-commented=1` is added, it sends notifications only when there are `@` mentions.
-#
+# 
 # Author:
 #   yujiosaka
 

--- a/src/github-pull-request.coffee
+++ b/src/github-pull-request.coffee
@@ -27,7 +27,7 @@ module.exports = (robot) ->
       only_mentioned: query["only-mentioned"]
       random_mention: +query["random-mention"]
       mention_team: query["mention-team"]
-      hidden_user_name: query["hidden-user-name"]
+      ignore_author: query["ignore-author"]
     parts = parseBody req.body
     message = lib.buildMessage parts, opts
     robot.send {room: query.room}, message if message

--- a/src/github-pull-request.coffee
+++ b/src/github-pull-request.coffee
@@ -7,9 +7,9 @@
 #   You need to add `HUBOT_URL/hubot/github-pull-request?room=ROOM[&only-mentioned=1]` to your repository's webhooks.
 #     HUBOT_URL: Your Hubot server's url
 #     ROOM` To which room you want to send notification
-# 
+#
 #     When `&only-commented=1` is added, it sends notifications only when there are `@` mentions.
-# 
+#
 # Author:
 #   yujiosaka
 
@@ -27,6 +27,7 @@ module.exports = (robot) ->
       only_mentioned: query["only-mentioned"]
       random_mention: +query["random-mention"]
       mention_team: query["mention-team"]
+      hidden_user_name: query["hidden-user-name"]
     parts = parseBody req.body
     message = lib.buildMessage parts, opts
     robot.send {room: query.room}, message if message

--- a/src/github-pull-request.coffee
+++ b/src/github-pull-request.coffee
@@ -27,7 +27,7 @@ module.exports = (robot) ->
       only_mentioned: query["only-mentioned"]
       random_mention: +query["random-mention"]
       mention_team: query["mention-team"]
-      ignore_author: query["ignore-author"]
+      ignore_sender: query["ignore-sender"]
     parts = parseBody req.body
     message = lib.buildMessage parts, opts
     robot.send {room: query.room}, message if message


### PR DESCRIPTION
Hello.

I am using the same ID for github and slack.

team.json is below.

```json
{
  "@hatappi": "<@hatappi>"
}
```

When commenting on GitHub, mention my account.
because sender's name is included in notification content.

![2017-03-07 20 57 35](https://cloud.githubusercontent.com/assets/3453977/23655540/b6972636-0378-11e7-9fbb-478deb7bec0f.png)

I looked for way user name is not notified, but I could not find it.
As a solution, added option to hide user name.

## Test Environment
`Hubot on Heroku`

- use `hidden-user-name=1` parameter

![image](https://cloud.githubusercontent.com/assets/3453977/23683434/51aef212-03dc-11e7-830e-7a30edb70eea.png)

- not use `hidden-user-name=1` parameter

![image](https://cloud.githubusercontent.com/assets/3453977/23683456/63dd7eb8-03dc-11e7-8c06-48590cf51fe9.png)
